### PR TITLE
update numpy dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,8 @@ install_requires =
     napari-clusters-plotter
     napari-skimage-regionprops
     napari[all]
-    numpy<1.22
+    numba>=0.55.2
+    numpy
     pyclesperanto-prototype
     pymeshfix
     scanpy


### PR DESCRIPTION
numba `0.55.2` has relaxed its numpy requirements, so we can now unpin numpy if we use `numba>=0.55.2`